### PR TITLE
fix: create-rx-bot file output and update templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ mock-telegram
 .rx-lab
 !jest.config.js
 packages/rxbot/test.ts
+packages/create-rx-bot/tests/test-bot

--- a/packages/create-rx-bot/package.json
+++ b/packages/create-rx-bot/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "cross-env NODE_ENV=production rspack build",
+    "build:local": "cross-env NODE_ENV=development rspack build && chmod +x dist/main.js && npm link",
     "postbuild": "chmod +x dist/main.js && npm link",
     "test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --runInBand --passWithNoTests --forceExit"
   },

--- a/packages/create-rx-bot/rspack.config.ts
+++ b/packages/create-rx-bot/rspack.config.ts
@@ -2,7 +2,10 @@ import * as path from "path";
 import { defineConfig } from "@rspack/cli";
 import { rspack } from "@rspack/core";
 
+const isProd = process.env.NODE_ENV === "production";
+
 export default defineConfig({
+  mode: isProd ? "production" : "development",
   entry: {
     main: "./src/index.ts",
   },
@@ -74,6 +77,11 @@ export default defineConfig({
     ],
   },
   plugins: [
+    new rspack.DefinePlugin({
+      "process.env.NODE_ENV": JSON.stringify(
+        isProd ? "production" : "development",
+      ),
+    }),
     new rspack.node.NodeTargetPlugin(),
     new rspack.BannerPlugin({
       banner: "#!/usr/bin/env node",

--- a/packages/create-rx-bot/src/index.ts
+++ b/packages/create-rx-bot/src/index.ts
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 
+import * as packageJson from "../package.json";
 import { render } from "./render";
 
 (async () => {
-  await render();
+  console.info("Creating Rx Bot...", process.env.NODE_ENV);
+  const isProd = process.env.NODE_ENV === "production";
+  const version = isProd ? packageJson.version : "latest";
+  await render(version);
 })();

--- a/packages/create-rx-bot/src/render.ts
+++ b/packages/create-rx-bot/src/render.ts
@@ -7,7 +7,8 @@ const DEFAULT_TEMPLATE_DIR = "templates";
 
 export async function render() {
   const engine = new ClarkEngine();
-  const cwd = __dirname;
+  const templateFolder = __dirname;
+  const outputFolder = process.cwd();
   try {
     const schemaPath = path.join(
       __dirname,
@@ -24,10 +25,13 @@ export async function render() {
     const renderer = createNodeGenerator({
       questionEngine: engine,
       userValues: results,
-      cwd: () => cwd,
+      getTemplateFolder: () => path.join(templateFolder, DEFAULT_TEMPLATE_DIR),
+      getOutputFolder: () => path.join(outputFolder, results.projectName),
     });
     await renderer.render();
-    await engine.end(`Successfully created ${results.projectName}`);
+    await engine.end(
+      `Successfully created ${results.projectName} at ${renderer.getOutputFolder()}`,
+    );
   } catch (error) {
     await engine.error(`Error creating project: ${error}`);
     process.exit(1);

--- a/packages/create-rx-bot/src/render.ts
+++ b/packages/create-rx-bot/src/render.ts
@@ -5,7 +5,7 @@ import * as yaml from "yaml";
 
 const DEFAULT_TEMPLATE_DIR = "templates";
 
-export async function render() {
+export async function render(version: string) {
   const engine = new ClarkEngine();
   const templateFolder = __dirname;
   const outputFolder = process.cwd();
@@ -17,14 +17,17 @@ export async function render() {
     );
     const schema = await fs.readFile(schemaPath, "utf-8");
     const parsedSchema = yaml.parse(schema);
-    await engine.start(parsedSchema.title || "Create Rx Bot");
+    await engine.start(`${parsedSchema.title || "Create Rx Bot"} (${version})`);
     const results = await ask({
       engine: engine,
       questions: parsedSchema,
     });
     const renderer = createNodeGenerator({
       questionEngine: engine,
-      userValues: results,
+      userValues: {
+        ...results,
+        packageVersion: version,
+      },
       getTemplateFolder: () => path.join(templateFolder, DEFAULT_TEMPLATE_DIR),
       getOutputFolder: () => path.join(outputFolder, results.projectName),
     });

--- a/packages/create-rx-bot/src/templates/package.json.tmpl
+++ b/packages/create-rx-bot/src/templates/package.json.tmpl
@@ -15,25 +15,25 @@
     "vercel": "^37.14.0"
   },
   "dependencies": {
-    "rxbot-cli": "latest",
+    "rxbot-cli": "{{packageVersion}}",
     "react": "^18.3.1",
     "dotenv": "^16.4.5",
     "react-reconciler": "^0.29.2",
     "@vercel/functions": "^1.5.0",
     "@types/react": "^18.3.12",
-    "@rx-lab/common": "latest",
-    "@rx-lab/core": "latest"
+    "@rx-lab/common": "{{packageVersion}}",
+    "@rx-lab/core": "{{packageVersion}}"
     {%- for adapter in adapters %}
       {%- if adapter === 'telegram' %},
-    "@rx-lab/telegram-adapter": "latest"
+    "@rx-lab/telegram-adapter": "{{packageVersion}}"
       {%- endif %}
     {%- endfor %}
     {%- if storage === 'upstash-redis' %},
-    "@rx-lab/upstash-storage": "latest"
+    "@rx-lab/upstash-storage": "{{packageVersion}}"
     {%- elif storage === 'memory' %},
-    "@rx-lab/storage": "latest"
+    "@rx-lab/storage": "{{packageVersion}}"
     {%- elif storage === 'file' %},
-    "@rx-lab/file-storage": "latest"
+    "@rx-lab/file-storage": "{{packageVersion}}"
     {%- endif %}
   }
 }

--- a/packages/create-rx-bot/src/templates/schema.yaml
+++ b/packages/create-rx-bot/src/templates/schema.yaml
@@ -53,4 +53,9 @@ properties:
         - title: Telegram
           const: telegram
           description: Build a bot for Telegram platform
+  shouldInstall:
+    type: boolean
+    title: Install dependencies
+    description: Whether to install dependencies after creating the project
+    default: true
 additionalProperties: false

--- a/packages/create-rx-bot/src/templates/templates.yaml.tmpl
+++ b/packages/create-rx-bot/src/templates/templates.yaml.tmpl
@@ -1,10 +1,12 @@
 files:
     - path: package.json.tmpl
       output: package.json
+      {% if shouldInstall %}
       hooks:
         afterAllEmit:
           type: shell
           command: {{packageManager}} install
+      {% endif %}
     - path: adapter.ts.tmpl
       output: src/app/adapter.ts
     - path: gitignore.tmpl

--- a/packages/create-rx-bot/tests/e2e.spec.ts
+++ b/packages/create-rx-bot/tests/e2e.spec.ts
@@ -8,12 +8,13 @@ import { CliInteraction } from "sourcecraft-core/test";
 describe("create-rx-bot", () => {
   const PROJECT_NAME = "test-bot";
   const currentDir = __dirname;
-  const projectDir = path.resolve(currentDir, "..", "dist", PROJECT_NAME);
+  const projectDir = path.resolve(currentDir, PROJECT_NAME);
   let cli: CliInteraction;
 
   afterEach(async () => {
     if (existsSync(projectDir)) {
-      // await fs.rm(projectDir, { recursive: true });
+      console.log("removing project dir", projectDir);
+      await fs.rm(projectDir, { recursive: true });
     }
     cli?.cleanup();
   });
@@ -42,7 +43,7 @@ describe("create-rx-bot", () => {
     cli.sendKey("ENTER");
 
     await cli.waitForOutput(
-      /Successfully created test-bot/,
+      /Successfully created/,
       process.env.CI ? 60_000 : 20_000,
     );
 

--- a/packages/create-rx-bot/tests/e2e.spec.ts
+++ b/packages/create-rx-bot/tests/e2e.spec.ts
@@ -21,7 +21,7 @@ describe("create-rx-bot", () => {
 
   it("should be able to build", async () => {
     console.log("currentDir", projectDir);
-    execSync("pnpm build", {
+    execSync("pnpm build:local", {
       cwd: currentDir,
     });
     cli = new CliInteraction({
@@ -40,6 +40,9 @@ describe("create-rx-bot", () => {
 
     await cli.waitForOutput(/Bot Adapters/);
     cli.sendKey("SPACE");
+    cli.sendKey("ENTER");
+
+    await cli.waitForOutput(/Install dependencies/);
     cli.sendKey("ENTER");
 
     await cli.waitForOutput(

--- a/packages/create-rx-bot/tsconfig.json
+++ b/packages/create-rx-bot/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es2022",
-    "moduleResolution": "nodenext"
+    "moduleResolution": "nodenext",
+    "resolveJsonModule": true
   }
 }

--- a/packages/sourcecraft-core/src/render/render.browser.ts
+++ b/packages/sourcecraft-core/src/render/render.browser.ts
@@ -45,7 +45,8 @@ export function createBrowserGenerator(opts: RenderBrowserOptions) {
     ...opts,
     fs: browserFs,
     path: browserPath,
-    cwd: () => "/",
+    getOutputFolder: () => "/output",
+    getTemplateFolder: () => "/templates",
     hookExecutor: {
       executeShell(command: string, cwd: string) {},
     },

--- a/packages/sourcecraft-core/src/render/render.node.ts
+++ b/packages/sourcecraft-core/src/render/render.node.ts
@@ -9,7 +9,8 @@ export function createNodeGenerator(
     ...opts,
     fs: require("fs"),
     path: require("path"),
-    cwd: opts.cwd,
+    getOutputFolder: opts.getOutputFolder,
+    getTemplateFolder: opts.getTemplateFolder,
     hookExecutor: {
       executeShell(command: string, cwd: string) {
         execSync(command, { stdio: "inherit", cwd });

--- a/packages/sourcecraft-core/src/render/render.spec.ts
+++ b/packages/sourcecraft-core/src/render/render.spec.ts
@@ -52,7 +52,8 @@ describe("TemplateGenerator", () => {
       path: mockPath,
       questionEngine: mockQuestionEngine,
       hookExecutor: mockHookExecutor,
-      cwd: () => "/test/cwd",
+      getTemplateFolder: () => "/test/template",
+      getOutputFolder: () => "/test/output",
     };
   });
 
@@ -117,7 +118,9 @@ files:
 
     it("should create project directory if it does not exist", async () => {
       await generator.render();
-      expect(mockFs.mkdirSync).toHaveBeenCalledWith("/test/cwd/test-project");
+      expect(mockFs.mkdirSync).toHaveBeenCalledWith("/test/output", {
+        recursive: true,
+      });
       expect(mockQuestionEngine.showLoading).toBeCalled();
       expect(mockQuestionEngine.hideLoading).toHaveBeenCalledTimes(1);
     });
@@ -132,7 +135,7 @@ files:
       await generator.render();
       expect(mockHookExecutor.executeShell).toHaveBeenCalledWith(
         "npm install",
-        "/test/cwd/test-project",
+        "/test/output",
       );
     });
 

--- a/packages/sourcecraft-core/src/test-utils/cli-tools.ts
+++ b/packages/sourcecraft-core/src/test-utils/cli-tools.ts
@@ -82,6 +82,7 @@ export class CliInteraction {
     });
 
     this.process.stderr?.on("data", (data: Buffer) => {
+      console.error(data.toString());
       this.stderr += data.toString();
     });
 


### PR DESCRIPTION
This pull request includes several changes to improve the build process, enhance environment handling, and update the project creation logic. The most important changes include setting environment variables, adding new build scripts, and updating the template rendering process.

### Environment and Build Configuration:
* [`.github/workflows/released.yaml`](diffhunk://#diff-ec89c842cc5df9e238ed938f9589a0bfd46e2c14534488676daa7c1994933ef5R11-R12): Added `NODE_ENV` environment variable set to `production` for the `release-npm` job.
* [`packages/create-rx-bot/package.json`](diffhunk://#diff-6abec5f2f70a23c5ca1424b15434eaef9d33994cb77d5c9c28f5a5beeab66ed0R12): Added a new script `build:local` for local development builds.
* [`packages/create-rx-bot/rspack.config.ts`](diffhunk://#diff-1148dc6e7afaccd4a4a39f77bc77a9fe597d7ea0b08a04b26d97a00d1a870ebcR5-R8): Introduced `isProd` variable to differentiate between production and development modes, and added `DefinePlugin` to set `process.env.NODE_ENV`. [[1]](diffhunk://#diff-1148dc6e7afaccd4a4a39f77bc77a9fe597d7ea0b08a04b26d97a00d1a870ebcR5-R8) [[2]](diffhunk://#diff-1148dc6e7afaccd4a4a39f77bc77a9fe597d7ea0b08a04b26d97a00d1a870ebcR80-R84)

### Template and Project Creation:
* [`packages/create-rx-bot/src/index.ts`](diffhunk://#diff-ebca93b8bb4fb9373efbc37cb251663e736a9979f105b2f4905bae3c1df3977aR3-R10): Updated the `render` function call to include the version based on the environment.
* [`packages/create-rx-bot/src/render.ts`](diffhunk://#diff-f9742e245785eba62ffad86d3a4cbd76c052acfe8756f2e739bde76e8936b4fcL8-R11): Modified the `render` function to accept a version parameter and updated paths and output folder logic. [[1]](diffhunk://#diff-f9742e245785eba62ffad86d3a4cbd76c052acfe8756f2e739bde76e8936b4fcL8-R11) [[2]](diffhunk://#diff-f9742e245785eba62ffad86d3a4cbd76c052acfe8756f2e739bde76e8936b4fcL19-R37)
* [`packages/create-rx-bot/src/templates/package.json.tmpl`](diffhunk://#diff-556642fbb6fce34158e89f0db5e1d183128f44332b314bba9693b3d591f29c8bL18-R36): Replaced hardcoded "latest" versions with `{{packageVersion}}` template variable.
* [`packages/create-rx-bot/src/templates/schema.yaml`](diffhunk://#diff-b050bc0c5e8aa0547c5684df21c1050560deb266a0ac2128032c7717b2ec2250R56-R60): Added a new property `shouldInstall` to determine if dependencies should be installed after project creation.
* [`packages/create-rx-bot/src/templates/templates.yaml.tmpl`](diffhunk://#diff-4579f6ebbbfef3f9a976defbaaaf58c16b7a8d3fb11f0ab4204a645d07492c34R4-R9): Added conditional logic to run `packageManager install` based on `shouldInstall` value.

### Testing and Miscellaneous:
* [`packages/create-rx-bot/tests/e2e.spec.ts`](diffhunk://#diff-1972a0975bb2424caa50e981ff04723eb51789cc23891fd05fe4fbf216ea4b31L11-R17): Updated project directory path and adjusted test expectations for project creation success message. [[1]](diffhunk://#diff-1972a0975bb2424caa50e981ff04723eb51789cc23891fd05fe4fbf216ea4b31L11-R17) [[2]](diffhunk://#diff-1972a0975bb2424caa50e981ff04723eb51789cc23891fd05fe4fbf216ea4b31L45-R46)
* [`packages/create-rx-bot/tsconfig.json`](diffhunk://#diff-602f59f99fc6e536eff9739b56eca34e7a79eaf44eb929da7cd58cdc66ec2c68L5-R6): Enabled `resolveJsonModule` to allow importing JSON files.
* [`packages/sourcecraft-core/src/render/render.node.ts`](diffhunk://#diff-f5e0e38ea2c0d89b081186d8939037e240e6d225333310025b1a3d65ac33cca9L12-R13): Updated `createNodeGenerator` to use `getOutputFolder` and `getTemplateFolder` methods.
* [`packages/sourcecraft-core/src/render/render.ts`](diffhunk://#diff-d1f2494fb0e4234c79082b4dc050eb647a65616ea6303dac7440f844b236a105L28-R59): Refactored `TemplateGenerator` to use new methods for template and output folders, and updated hook execution paths. [[1]](diffhunk://#diff-d1f2494fb0e4234c79082b4dc050eb647a65616ea6303dac7440f844b236a105L28-R59) [[2]](diffhunk://#diff-d1f2494fb0e4234c79082b4dc050eb647a65616ea6303dac7440f844b236a105L95-R89) [[3]](diffhunk://#diff-d1f2494fb0e4234c79082b4dc050eb647a65616ea6303dac7440f844b236a105L152-R153) [[4]](diffhunk://#diff-d1f2494fb0e4234c79082b4dc050eb647a65616ea6303dac7440f844b236a105L177-R189)
* [`packages/sourcecraft-core/src/test-utils/cli-tools.ts`](diffhunk://#diff-152ab136d176d35ee71954c5837b559412b44cbd59d9eb43c5fadf79def43c87R85): Added logging for stderr in `CliInteraction` for better debugging.