### PR TITLE
fix: @rx-lab/mock-telegram-client public and publish it to npm

### DIFF
--- a/packages/mock-telegram/package.json
+++ b/packages/mock-telegram/package.json
@@ -2,7 +2,7 @@
   "name": "@rx-lab/mock-telegram-client",
   "version": "1.0.0",
   "description": "",
-  "private": true,
+  "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
@@ -13,6 +13,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "swagger-typescript-api": "^13.0.3",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
Make `@rx-lab/mock-telegram-client` public and publish it to npm.

* Set the `private` field to `false` in `packages/mock-telegram/package.json`.
* Add `publishConfig` field with `access` set to `public` in `packages/mock-telegram/package.json`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rxtech-lab/rxbot-core/pull/177?shareId=eaecff42-f3f5-4583-8af5-bcd4c310839e).