### PR TITLE
fix: modify build and bump version ci order

### DIFF
--- a/.github/workflows/released.yaml
+++ b/.github/workflows/released.yaml
@@ -18,17 +18,17 @@ jobs:
           version: latest
       - name: Install dependencies
         run: pnpm install
-      - name: Build packages
-        run: |
-          pnpm build --filter=rxbot-cli
-          pnpm install --no-frozen-lockfile  # Reinstall to update binaries
-          pnpm build --filter=!rxbot-cli
       - name: Lerna Bump Version on release
         run: pnpm lerna version ${{ github.event.release.tag_name }} --no-git-tag-version --no-push --yes
         if: github.event_name == 'release'
       - name: Lerna Bump Version on push
         run: pnpm lerna version 1.0.0-next --no-git-tag-version --no-push --yes
         if: github.event_name == 'push'
+      - name: Build packages
+        run: |
+          pnpm build --filter=rxbot-cli
+          pnpm install --no-frozen-lockfile  # Reinstall to update binaries
+          pnpm build --filter=!rxbot-cli
       - name: Add and commit version changed
         uses: EndBug/add-and-commit@v9
         with:


### PR DESCRIPTION
This pull request includes a reordering of steps in the `.github/workflows/released.yaml` file to ensure that the build process occurs after the version bump steps. This change aims to streamline the workflow and ensure that the packages are built with the correct version.

Changes in the build process:

* [`.github/workflows/released.yaml`](diffhunk://#diff-ec89c842cc5df9e238ed938f9589a0bfd46e2c14534488676daa7c1994933ef5L21-R31): Moved the `Build packages` step to occur after the version bump steps for both release and push events.