### PR TITLE
fix: add code block support

### DIFF
--- a/apps/example-bot/src/app/page.tsx
+++ b/apps/example-bot/src/app/page.tsx
@@ -7,6 +7,7 @@ export default async function Page() {
         <br />
         Click the menu button to see the available options.
       </p>
+      <code>Hello</code>
     </div>
   );
 }

--- a/packages/common/src/hostconfig.interface.ts
+++ b/packages/common/src/hostconfig.interface.ts
@@ -28,6 +28,8 @@ export enum InstanceType {
   Image = "Image",
   LineBreak = "LineBreak",
   Suspendable = "Suspendable",
+  Code = "Code",
+  Pre = "Pre",
 }
 
 /**

--- a/packages/common/src/react.ts
+++ b/packages/common/src/react.ts
@@ -48,6 +48,8 @@ export enum ReactInstanceType {
   ThematicBreak = "hr",
   Suspendable = "suspendable",
   Command = "command",
+  Pre = "pre",
+  Code = "code",
 }
 
 export const REACT_COMPONENT_TYPE = "react.element";

--- a/packages/core/src/components/Code.ts
+++ b/packages/core/src/components/Code.ts
@@ -1,0 +1,13 @@
+import { InstanceType } from "@rx-lab/common";
+import { BaseComponent } from "./Component";
+
+/**
+ * Link component is used to render an external link in the bot.
+ */
+export class Code extends BaseComponent<any> {
+  type = InstanceType.Code;
+}
+
+export class Pre extends BaseComponent<any> {
+  type = InstanceType.Pre;
+}

--- a/packages/core/src/components/builder/componentBuilder.ts
+++ b/packages/core/src/components/builder/componentBuilder.ts
@@ -13,6 +13,7 @@ import {
   UnsupportedComponentError,
   UnsupportedReactComponentError,
 } from "@rx-lab/errors";
+import { Code, Pre } from "../Code";
 import {
   type BaseComponent,
   Button,
@@ -60,6 +61,8 @@ export class ComponentBuilder implements Builder {
     [InstanceType.Command]: CommandComponent as unknown as Constructor<
       BaseComponent<any>
     >,
+    [InstanceType.Code]: Code,
+    [InstanceType.Pre]: Pre,
   };
 
   /**
@@ -87,6 +90,8 @@ export class ComponentBuilder implements Builder {
     [ReactInstanceType.Suspendable]: InstanceType.Suspendable,
     [ReactInstanceType.Link]: InstanceType.Link,
     [ReactInstanceType.Command]: InstanceType.Command,
+    [ReactInstanceType.Pre]: InstanceType.Pre,
+    [ReactInstanceType.Code]: InstanceType.Code,
   };
 
   build(

--- a/packages/telegram-adapter/src/renderer.spec.tsx
+++ b/packages/telegram-adapter/src/renderer.spec.tsx
@@ -33,6 +33,34 @@ describe("renderElement", () => {
     expect(renderElement(textElement, parser).text).toBe("Hello");
   });
 
+  it("should render inline code", () => {
+    const codeElement = new MockComponent("1", InstanceType.Code, {
+      children: [
+        new MockComponent("1", InstanceType.Text, {
+          nodeValue: "const a = 1;",
+        }),
+      ],
+    });
+    const rendered = renderElement(codeElement, parser);
+    expect(rendered.text).toBe("<code>const a = 1;</code>");
+  });
+
+  it("should render code block", () => {
+    const codeElement = new MockComponent("1", InstanceType.Pre, {
+      children: [
+        new MockComponent("1", InstanceType.Code, {
+          children: [
+            new MockComponent("1", InstanceType.Text, {
+              nodeValue: "const a = 1;",
+            }),
+          ],
+        }),
+      ],
+    });
+    const rendered = renderElement(codeElement, parser);
+    expect(rendered.text).toBe("<pre><code>const a = 1;</code></pre>");
+  });
+
   it("should render button element", () => {
     const buttonElement = new MockComponent("2", InstanceType.Button, {
       children: [

--- a/packages/telegram-adapter/src/renderer.ts
+++ b/packages/telegram-adapter/src/renderer.ts
@@ -40,7 +40,10 @@ export const renderElementHelper = (
 
     case InstanceType.Link:
       return [`<a href="${element.props.href}">${children.join("")}</a>`];
-
+    case InstanceType.Pre:
+      return [`<pre>${children.join("")}</pre>`];
+    case InstanceType.Code:
+      return [`<code>${children.join("")}</code>`];
     case InstanceType.Command:
       if (element.props.variant === "button") {
         if (element.props.command.startsWith("http")) {


### PR DESCRIPTION
This pull request introduces new components for rendering code and preformatted text, along with corresponding updates to the component builder and tests. The most important changes include adding the `Code` and `Pre` components, updating enums, and ensuring proper rendering in the Telegram adapter.

### New Components:
* Added `Code` and `Pre` components in `packages/core/src/components/Code.ts` with corresponding imports and type assignments. [[1]](diffhunk://#diff-e322d030cc593566ea3def722bb5e554d9eeaa92a151817e39de71e3c06f4687R1-R13) [[2]](diffhunk://#diff-c2312ce7c518608733ef1737fd19983c935fd4994d2e6f7ce2bd407914e34f8dR16) [[3]](diffhunk://#diff-c2312ce7c518608733ef1737fd19983c935fd4994d2e6f7ce2bd407914e34f8dR64-R65)

### Enum Updates:
* Added `Code` and `Pre` to `InstanceType` and `ReactInstanceType` enums in `packages/common/src/hostconfig.interface.ts` and `packages/common/src/react.ts`. [[1]](diffhunk://#diff-56f6db168d53ce90f988f85d5d2c43c3cd75ce91832772dd6064e4551ddc69a2R31-R32) [[2]](diffhunk://#diff-e449135f15f52011ef014039618bbf257b21c58650e269a12437fdf2bc3ed311R51-R52)

### Component Builder Updates:
* Updated `ComponentBuilder` to include `Code` and `Pre` components for both `InstanceType` and `ReactInstanceType` mappings in `packages/core/src/components/builder/componentBuilder.ts`.

### Rendering Updates:
* Updated `renderElementHelper` to handle `Code` and `Pre` components in `packages/telegram-adapter/src/renderer.ts`.
* Added tests for rendering `Code` and `Pre` components in `packages/telegram-adapter/src/renderer.spec.tsx`.

### Minor UI Update:
* Added a `<code>Hello</code>` element to the `Page` component in `apps/example-bot/src/app/page.tsx`.