### PR TITLE
Include aggregated code coverage report in PR

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,3 +17,11 @@ jobs:
         run: pnpm lint
       - name: Test
         run: ./scripts/test.sh
+      - name: Run coverage using turbo
+        run: pnpm turbo run coverage
+      - name: Aggregate coverage reports
+        run: node scripts/aggregate-coverage.js
+      - name: Publish coverage report to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage/coverage-final.json

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,11 +17,11 @@ jobs:
         run: pnpm lint
       - name: Test
         run: ./scripts/test.sh
-      - name: Run coverage using turbo
-        run: pnpm turbo run coverage
       - name: Aggregate coverage reports
         run: node scripts/aggregate-coverage.js
       - name: Publish coverage report to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
-          file: ./coverage/coverage-final.json
+          files: ./coverage/coverage-final.json
+          token: ${{ secrets.CODECOV_TOKEN }}
+

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "turbo dev",
     "lint": "biome lint",
     "test": "turbo test --concurrency=1",
+    "coverage": "turbo coverage --concurrency=1",
     "format": "biome format --write .",
     "format:version": "syncpack fix-mismatches",
     "publish:dry": "lerna publish from-package --no-push"
@@ -17,7 +18,8 @@
     "prettier": "3.3.3",
     "syncpack": "13.0.0",
     "turbo": "2.2.3",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "glob": "^11.0.0"
   },
   "packageManager": "pnpm@9.4.0",
   "version": "^3.23.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc"
+    "build": "tsc",
+    "coverage": "jest --coverage"
   },
   "keywords": [],
   "author": "",

--- a/packages/create-rx-bot/package.json
+++ b/packages/create-rx-bot/package.json
@@ -11,7 +11,8 @@
     "build": "cross-env NODE_ENV=production rspack build",
     "build:local": "cross-env NODE_ENV=development rspack build && chmod +x dist/main.js && npm link",
     "postbuild": "chmod +x dist/main.js && npm link",
-    "test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --runInBand --passWithNoTests --forceExit"
+    "test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --runInBand --passWithNoTests --forceExit",
+    "coverage": "jest --coverage"
   },
   "devDependencies": {
     "@rspack/cli": "1.1.0",

--- a/packages/file-storage/package.json
+++ b/packages/file-storage/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc"
+    "build": "tsc",
+    "coverage": "jest --coverage"
   },
   "files": ["dist"],
   "publishConfig": {

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -18,7 +18,8 @@
   },
   "scripts": {
     "test": "jest --passWithNoTests",
-    "build": "tsc"
+    "build": "tsc",
+    "coverage": "jest --coverage"
   },
   "keywords": [],
   "author": "",

--- a/packages/rxbot/package.json
+++ b/packages/rxbot/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "build": "tsc && rspack build --config rspack.config.executables.ts",
     "postbuild": "chmod +x ./executables/rxbot.js",
-    "test": "jest --runInBand"
+    "test": "jest --runInBand",
+    "coverage": "jest --coverage"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rxbot/package.json
+++ b/packages/rxbot/package.json
@@ -15,7 +15,7 @@
     "build": "tsc && rspack build --config rspack.config.executables.ts",
     "postbuild": "chmod +x ./executables/rxbot.js",
     "test": "jest --runInBand",
-    "coverage": "jest --coverage"
+    "coverage": "jest --runInBand --coverage"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rxbot/src/command/commands/build/build.spec.ts
+++ b/packages/rxbot/src/command/commands/build/build.spec.ts
@@ -37,5 +37,5 @@ describe("build.vercel", () => {
     if (consoleErrorCalls.length > 0) {
       expect(consoleErrorCalls[0][0].message).not.toContain("is required");
     }
-  });
+  }, 30_000);
 });

--- a/packages/sourcecraft-core/package.json
+++ b/packages/sourcecraft-core/package.json
@@ -22,7 +22,8 @@
   },
   "scripts": {
     "test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest",
-    "build": "tsc"
+    "build": "tsc",
+    "coverage": "jest --coverage"
   },
   "keywords": [],
   "author": "",

--- a/packages/sourcecraft-core/package.json
+++ b/packages/sourcecraft-core/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest",
     "build": "tsc",
-    "coverage": "jest --coverage"
+    "coverage": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --coverage"
   },
   "keywords": [],
   "author": "",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -18,7 +18,8 @@
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc"
+    "build": "tsc",
+    "coverage": "jest --coverage"
   },
   "keywords": [],
   "author": "",

--- a/packages/telegram-adapter/package.json
+++ b/packages/telegram-adapter/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "jest"
+    "test": "jest",
+    "coverage": "jest --coverage"
   },
   "keywords": [],
   "author": "",

--- a/packages/upstash-storage/package.json
+++ b/packages/upstash-storage/package.json
@@ -10,7 +10,8 @@
   "files": ["dist"],
   "scripts": {
     "test": "jest",
-    "build": "tsc"
+    "build": "tsc",
+    "coverage": "jest --coverage"
   },
   "keywords": [],
   "author": "",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@types/node':
         specifier: 22.9.0
         version: 22.9.0
+      glob:
+        specifier: ^11.0.0
+        version: 11.0.0
       lerna:
         specifier: 8.1.9
         version: 8.1.9(@swc/core@1.7.14)(encoding@0.1.13)

--- a/scripts/aggregate-coverage.js
+++ b/scripts/aggregate-coverage.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const packagesDir = path.resolve(__dirname, '../packages');
+const coverageDir = path.resolve(__dirname, '../coverage');
+const mergedCoverageFile = path.join(coverageDir, 'coverage-final.json');
+
+if (!fs.existsSync(coverageDir)) {
+  fs.mkdirSync(coverageDir);
+}
+
+const coverageFiles = [];
+
+fs.readdirSync(packagesDir).forEach(packageName => {
+  const packageDir = path.join(packagesDir, packageName);
+  const packageCoverageFile = path.join(packageDir, 'coverage', 'coverage-final.json');
+
+  if (fs.existsSync(packageCoverageFile)) {
+    coverageFiles.push(packageCoverageFile);
+  }
+});
+
+if (coverageFiles.length === 0) {
+  console.log('No coverage files found.');
+  process.exit(0);
+}
+
+const mergeCommand = `npx nyc merge ${coverageFiles.join(' ')} -o ${mergedCoverageFile}`;
+execSync(mergeCommand);
+
+console.log(`Merged coverage report saved to ${mergedCoverageFile}`);

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,4 +9,4 @@ mock-telegram serve --bind 0.0.0.0:9000 &
 # Run tests
 pnpm build --filter=rxbot-cli
 pnpm install --no-frozen-lockfile  # Reinstall to update binaries
-pnpm test
+pnpm coverage

--- a/tests/telegram-e2e-tests/package.json
+++ b/tests/telegram-e2e-tests/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --forceExit --runInBand"
+    "test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --forceExit --runInBand",
+    "coverage": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --coverage --forceExit --runInBand"
   },
   "keywords": [],
   "author": "",

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,10 @@
     "test": {
       "inputs": ["*.spec.*"],
       "dependsOn": ["^build"]
+    },
+    "coverage": {
+      "inputs": ["*.spec.*"],
+      "dependsOn": ["^build"]
     }
   }
 }


### PR DESCRIPTION
Fixes #221

Add code coverage reporting and aggregation to the project.

* **Add coverage command to package.json files**
  - Add a `coverage` command to the `scripts` section in `packages/core/package.json`, `packages/create-rx-bot/package.json`, `packages/file-storage/package.json`, `packages/router/package.json`, `packages/rxbot/package.json`, `packages/sourcecraft-core/package.json`, `packages/storage/package.json`, `packages/telegram-adapter/package.json`, and `packages/upstash-storage/package.json`.

* **Create aggregate-coverage.js script**
  - Create `scripts/aggregate-coverage.js` to collect and merge individual coverage reports into a single aggregated coverage report.

* **Update GitHub Actions workflow**
  - Modify `.github/workflows/main.yaml` to include steps for running coverage using turbo, aggregating coverage reports, and publishing the aggregated coverage report to Codecov.

* **Update turbo.json**
  - Add a coverage step in the turbo configuration in `turbo.json`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rxtech-lab/rxbot-core/pull/225?shareId=620b53eb-546c-43c7-a2e0-d5b5178f6345).