### PR TITLE
fix: add support for telegram link with search query

### DIFF
--- a/apps/example-bot/src/app/page.tsx
+++ b/apps/example-bot/src/app/page.tsx
@@ -19,7 +19,6 @@ export default async function Page({
         <br />
         Click the menu button to see the available options.
       </p>
-      <code>Hello</code>
     </div>
   );
 }

--- a/packages/core/src/core/core.tsx
+++ b/packages/core/src/core/core.tsx
@@ -370,6 +370,14 @@ export class Core<T extends Container<BaseChatroomInfo, BaseMessage>>
         type: "page",
       },
     );
+    // if there is a parse search query, pass it to the component
+    if (component.queryString) {
+      component.queryString = {
+        ...component.queryString,
+        ...defaultRoute?.props?.searchQuery,
+      };
+    }
+
     await this.setComponent(component);
     return component;
   }

--- a/packages/telegram-adapter/src/renderer.ts
+++ b/packages/telegram-adapter/src/renderer.ts
@@ -51,7 +51,7 @@ export const renderElementHelper = (
       return [`<code>${children.join("")}</code>`];
     case InstanceType.Command:
       if (element.props.variant === "button") {
-        if (element.props.command.startsWith("http")) {
+        if (element.props.webapp) {
           return {
             type: "button",
             text: children.join(""),
@@ -60,6 +60,15 @@ export const renderElementHelper = (
             },
           };
         }
+
+        if (element.props.command.startsWith("http")) {
+          return {
+            type: "button",
+            text: children.join(""),
+            url: element.props.command,
+          };
+        }
+
         const callbackData = {
           route: convertRouteToTGRoute(element.props.command),
           new: element.props.renderNewMessage,
@@ -169,8 +178,13 @@ export const renderElement = (
         text: res.text,
         callback_data: res.callback_data,
       };
+
       if (res.web_app) {
         button.web_app = res.web_app;
+      }
+
+      if (res.url) {
+        button.url = res.url;
       }
 
       if (level === 1) {

--- a/packages/telegram-adapter/src/utils.ts
+++ b/packages/telegram-adapter/src/utils.ts
@@ -55,6 +55,7 @@ export function convertTGRouteToRoute(route: StoredRoute): string {
 
   // Find the position of the first underscore
   const firstUnderscoreIndex = route.route.indexOf("_");
+  const startPayload = route.route.split(" ")[1];
 
   // If there's no underscore, return the route as is
   if (firstUnderscoreIndex === -1) {


### PR DESCRIPTION
Add support for telegram inline button with url attribute. Allow user pass query string to a chatbot and parse it in Telegram adapter