### PR TITLE
fix: inject fs for better testing

### DIFF
--- a/packages/rxbot/package.json
+++ b/packages/rxbot/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsc && rspack build --config rspack.config.executables.ts",
+    "build": "tsc -p tsconfig.build.json && rspack build --config rspack.config.executables.ts",
     "postbuild": "chmod +x ./executables/rxbot.js",
     "test": "jest --runInBand",
     "coverage": "jest --runInBand --coverage"
@@ -24,6 +24,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@jest/globals": "^29.7.0",
     "@rspack/cli": "1.1.0",
     "@rspack/core": "1.1.0",
     "@rspack/dev-server": "^1.0.9",
@@ -33,10 +34,12 @@
     "@swc/core": "^1.7.10",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.12",
+    "@types/memory-fs": "^0.3.7",
     "@types/yargs": "^17.0.33",
     "@vercel/functions": "^1.4.1",
     "express": "^4.21.1",
     "glob": "^11.0.0",
+    "memory-fs": "^0.5.0",
     "totalist": "^3.0.1",
     "yargs": "^17.7.2",
     "zod": "^3.23.8"

--- a/packages/rxbot/src/compiler/compiler.spec.ts
+++ b/packages/rxbot/src/compiler/compiler.spec.ts
@@ -1,266 +1,131 @@
-import * as fs from "fs";
-import { describe } from "node:test";
-import * as swc from "@swc/core";
+//@ts-ignore
+import MemoryFS from "memory-fs";
+import { describe, expect, it, beforeEach, jest } from "@jest/globals";
+import { Compiler } from "./compiler";
 import { glob } from "glob";
-import { Compiler, CompilerOptions, CompilerUtils } from "./compiler";
-import { readMetadata } from "./utils";
-// Mock dependencies
-jest.mock("@swc/core", () => ({
-  transformFile: jest.fn(),
-  transform: jest.fn().mockResolvedValue({
-    code: "compiled code",
-    ast: {},
-  }),
-}));
 
-jest.mock("./utils", () => ({
-  readMetadata: jest.fn(),
-  isTypeScript: jest.fn().mockReturnValue(true),
-  parseSourceCode: jest.fn(),
-  generateClientComponentTag: jest.fn().mockReturnValue(""),
-  checkDuplicateKeys: jest.fn(),
-  extractJSXKeyAttributes: jest.fn().mockReturnValue([
-    {
-      value: "key1",
-    },
-    {
-      value: "key2",
-    },
-  ]),
-}));
+jest.mock("glob");
 
-// Mock the glob module
-jest.mock("glob", () => ({
-  glob: {
-    glob: jest.fn(),
-  },
-}));
-
-jest.mock("fs", () => ({
-  writeFileSync: jest.fn(),
-  existsSync: jest.fn().mockReturnValue(true),
-  readFileSync: jest.fn(),
-  rmSync: jest.fn(),
-  mkdirSync: jest.fn(),
-}));
-
-describe("buildRouteInfo", () => {
+describe("Compiler", () => {
+  let fs: MemoryFS;
   let compiler: Compiler;
-  const mockOptions: CompilerOptions = {
-    rootDir: "/src",
-    destinationDir: "/dist",
-  };
+  const sourceDir = "/src";
+  const destDir = "/dist";
 
   beforeEach(() => {
-    compiler = new Compiler(mockOptions);
+    fs = new MemoryFS();
+
+    // Set up initial directory structure
+    fs.mkdirpSync(sourceDir);
+    fs.mkdirpSync(destDir);
+    fs.mkdirpSync(`${sourceDir}/app`);
+    fs.mkdirpSync(`${sourceDir}/app/home`);
+    fs.mkdirpSync(`${destDir}/app`);
+    fs.mkdirpSync(`${destDir}/app/home`);
+
+    compiler = new Compiler({
+      rootDir: sourceDir,
+      destinationDir: destDir,
+      fs: fs as any,
+    });
+
+    // Set up test files in memory
+    fs.writeFileSync(
+      `${sourceDir}/app/home/page.tsx`,
+      `
+        export default function HomePage() {
+          return <div>Home</div>;
+        }
+      `,
+    );
   });
 
-  it("should correctly build route info for a single page", async () => {
-    const result = await compiler.buildRouteInfo([
-      {
-        code: "",
-        ast: {} as any,
-        outputFilePath: "/dist/app/page.js",
-        outputDir: "/dist/app",
-        sourceCodePath: "/src/app/page.tsx",
-      },
-    ]);
+  describe("Route Generation", () => {
+    it("should generate correct route structure for simple page", async () => {
+      jest.spyOn(glob, "glob").mockImplementation(async () => {
+        return ["/app/home/page.tsx"];
+      });
 
-    expect(result).toEqual([
-      {
-        page: "/dist/app/page.js",
+      const result = await compiler.compile();
+
+      expect(result.routes).toHaveLength(1);
+      expect(result.routes[0]).toMatchObject({
         route: "/",
-        subRoutes: [],
-      },
-    ]);
-  });
-
-  it("should correctly build route info for nested pages", async () => {
-    const result = await compiler.buildRouteInfo([
-      {
-        code: "",
-        ast: {} as any,
-        outputFilePath: "/dist/app/page.js",
-        outputDir: "/dist/app",
-        sourceCodePath: "/src/app/page.tsx",
-      },
-      {
-        code: "",
-        ast: {} as any,
-        outputFilePath: "/dist/app/dashboard/settings/page.js",
-        outputDir: "/dist/app/nested",
-        sourceCodePath: "/src/app/dashboard/settings/page.tsx",
-      },
-    ]);
-
-    expect(result).toEqual([
-      {
-        route: "/",
-        page: "/dist/app/page.js",
-        subRoutes: [],
-      },
-      {
-        route: "/dashboard",
+        page: expect.stringContaining("/dist/app/page.js"),
+        "404": expect.stringContaining("/dist/app/404.js"),
+        error: expect.stringContaining("/dist/app/error.js"),
         subRoutes: [
           {
-            route: "/dashboard/settings",
-            page: "/dist/app/dashboard/settings/page.js",
-            subRoutes: [],
+            route: "/home",
+            page: expect.stringContaining("/dist/app/home/page.js"),
           },
         ],
-      },
-    ]);
-  });
-
-  it("should return an empty array when no pages are found", async () => {
-    (glob.glob as jest.Mock).mockResolvedValue([]);
-
-    const result = await compiler.buildRouteInfo([]);
-
-    expect(result).toEqual([]);
-  });
-});
-
-describe("Compiler.compile", () => {
-  let compiler: Compiler;
-  const mockOptions: CompilerOptions = {
-    rootDir: "/path/to/project",
-    destinationDir: "/path/to/output",
-  };
-
-  beforeEach(() => {
-    compiler = new Compiler(mockOptions);
-    jest.clearAllMocks();
-  });
-
-  it("should compile a single page without root route", async () => {
-    const mockPages = ["/app/home/page.tsx"];
-    (require("glob").glob.glob as jest.Mock).mockResolvedValue(mockPages);
-    (swc.transformFile as jest.Mock).mockResolvedValue({
-      code: "compiled code",
+      });
     });
-    (readMetadata as jest.Mock).mockResolvedValue({ title: "Home" });
 
-    const result = await compiler.compile();
+    it("should handle nested routes correctly", async () => {
+      fs.mkdirpSync(`${sourceDir}/app/home/nested`);
+      fs.writeFileSync(
+        `${sourceDir}/app/home/nested/page.tsx`,
+        `
+          export default function NestedPage() {
+            return <div>Nested</div>;
+          }
+        `,
+      );
+      jest.spyOn(glob, "glob").mockImplementation(async () => {
+        return ["/app/home/page.tsx", "/app/home/nested/page.tsx"];
+      });
 
-    expect(result).toStrictEqual({
-      routes: [
-        {
-          route: "/",
-          page: "/path/to/output/app/page.js",
-          "404": "/path/to/output/app/404.js",
-          error: "/path/to/output/app/error.js",
-          metadata: undefined,
-          subRoutes: [
-            {
-              route: "/home",
-              page: "/path/to/output/app/home/page.js",
-              "404": "/path/to/output/app/404.js",
-              error: "/path/to/output/app/error.js",
-              subRoutes: [],
-              metadata: { title: "Home" },
-            },
-          ],
-        },
-      ],
+      const result = await compiler.compile();
+
+      expect(result.routes[0].subRoutes![0].subRoutes).toHaveLength(1);
+      expect(result.routes[0].subRoutes![0].subRoutes![0]).toMatchObject({
+        route: "/home/nested",
+        page: expect.stringContaining("/dist/app/home/nested/page.js"),
+      });
     });
-  });
 
-  it("should compile a single page with root route", async () => {
-    const mockPages = ["/app/page.tsx"];
-    (require("glob").glob.glob as jest.Mock).mockResolvedValue(mockPages);
-    (swc.transformFile as jest.Mock).mockResolvedValue({
-      code: "compiled code",
+    it("should handle custom error pages", async () => {
+      fs.writeFileSync(
+        `${sourceDir}/app/home/error.tsx`,
+        `
+          export default function ErrorPage() {
+            return <div>Custom Error</div>;
+          }
+        `,
+      );
+      jest.spyOn(glob, "glob").mockImplementation(async () => {
+        return ["/app/home/page.tsx", "/app/home/error.tsx"];
+      });
+
+      const result = await compiler.compile();
+
+      expect(result.routes[0].subRoutes![0]).toMatchObject({
+        route: "/home",
+        error: expect.stringContaining("/dist/app/home/error.js"),
+      });
     });
-    (readMetadata as jest.Mock).mockResolvedValue({ title: "Home" });
-    (fs.existsSync as jest.Mock)
-      .mockReturnValueOnce(false)
-      .mockReturnValueOnce(false)
-      .mockReturnValueOnce(false);
 
-    const result = await compiler.compile();
+    it("should handle custom 404 pages", async () => {
+      fs.writeFileSync(
+        `${sourceDir}/app/home/404.tsx`,
+        `
+          export default function NotFoundPage() {
+            return <div>Custom 404</div>;
+          }
+        `,
+      );
+      jest.spyOn(glob, "glob").mockImplementation(async () => {
+        return ["/app/home/page.tsx", "/app/home/404.tsx"];
+      });
 
-    expect(result).toStrictEqual({
-      routes: [
-        {
-          route: "/",
-          page: "/path/to/output/app/page.js",
-          "404": "/path/to/output/app/404.js",
-          error: "/path/to/output/app/error.js",
-          metadata: { title: "Home" },
-          subRoutes: [],
-        },
-      ],
-    });
-  });
+      const result = await compiler.compile();
 
-  it("should handle compilation errors", async () => {
-    const mockPages = ["/path/to/project/error/page.tsx"];
-    (require("glob").glob.glob as jest.Mock).mockResolvedValue(mockPages);
-    (swc.transformFile as jest.Mock).mockRejectedValue(
-      new Error("Compilation error"),
-    );
-    (readMetadata as jest.Mock).mockResolvedValue({});
-
-    await expect(compiler.compile()).rejects.toThrow("Compilation error");
-  });
-
-  it("should use default output directory if not specified", async () => {
-    const compilerWithoutDestDir = new Compiler({
-      rootDir: "/path/to/project",
-    });
-    const mockPages = ["/path/to/project/home/page.tsx"];
-    (require("glob").glob.glob as jest.Mock).mockResolvedValue(mockPages);
-    (swc.transformFile as jest.Mock).mockResolvedValue({
-      code: "compiled code",
-    });
-    (readMetadata as jest.Mock).mockResolvedValue({});
-
-    await compilerWithoutDestDir.compile();
-  });
-
-  it("should handle empty project with no pages", async () => {
-    (require("glob").glob.glob as jest.Mock).mockResolvedValue([]);
-
-    const result = await compiler.compile();
-
-    expect(result).toEqual({
-      routes: [
-        {
-          "404": "/path/to/output/app/404.js",
-          error: "/path/to/output/app/error.js",
-          page: "/path/to/output/app/page.js",
-          route: "/",
-          subRoutes: [],
-        },
-      ],
-    });
-    expect(swc.transformFile).not.toHaveBeenCalled();
-    expect(readMetadata).not.toHaveBeenCalled();
-  });
-});
-
-describe("Compiler.getOutputPath", () => {
-  const testCases = [
-    {
-      input: "/path/to/project/home/page.ts",
-      output: "page.js",
-    },
-    {
-      input: "/path/to/project/page.tsx",
-      output: "page.js",
-    },
-    {
-      input: "/path/to/project/home/page.tsx",
-      output: "page.js",
-    },
-  ];
-
-  testCases.forEach(({ input, output }) => {
-    it(`should correctly generate output path for ${input}`, () => {
-      const utils = new CompilerUtils("/path/to/project", "/path/to/output");
-      const result = utils.getOutputPath(input);
-      expect(result.outputFileName).toContain(output);
+      expect(result.routes[0].subRoutes![0]).toMatchObject({
+        route: "/home",
+        "404": expect.stringContaining("/dist/app/home/404.js"),
+      });
     });
   });
 });

--- a/packages/rxbot/tsconfig.build.json
+++ b/packages/rxbot/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false,
+    "inlineSourceMap": true
+  }
+}

--- a/packages/rxbot/tsconfig.json
+++ b/packages/rxbot/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "nodenext",
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": false,
+    "sourceMap": true,
     "inlineSourceMap": true,
     "moduleResolution": "node16",
     "outDir": "./dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,7 +182,7 @@ importers:
         version: 0.28.8
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.10)(@types/node@22.9.0)(typescript@5.6.3))
+        version: 29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3))
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -191,7 +191,7 @@ importers:
         version: 0.29.2(react@18.3.1)
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.10)(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3)
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -218,7 +218,7 @@ importers:
         version: link:../sourcecraft-core
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3)
       yaml:
         specifier: ^2.4.2
         version: 2.5.0
@@ -228,7 +228,7 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 1.1.0
-        version: 1.1.0(@rspack/core@1.1.0)(@types/express@5.0.0)(webpack@5.96.1(@swc/core@1.7.14))
+        version: 1.1.0(@rspack/core@1.1.0)(webpack@5.96.1(@swc/core@1.7.14))
       '@rspack/core':
         specifier: 1.1.0
         version: 1.1.0
@@ -268,7 +268,7 @@ importers:
         version: 7.1.0(eslint@8.57.0)(typescript@5.6.3)
       '@vercel/style-guide':
         specifier: ^5.2.0
-        version: 5.2.0(eslint@8.57.0)(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)))(prettier@3.3.3)(typescript@5.6.3)
+        version: 5.2.0(eslint@8.57.0)(jest@29.7.0(@types/node@22.9.0))(prettier@3.3.3)(typescript@5.6.3)
       eslint-config-prettier:
         specifier: ^9.1.0
         version: 9.1.0(eslint@8.57.0)
@@ -317,7 +317,7 @@ importers:
         version: 29.7.0
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3)
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -403,13 +403,16 @@ importers:
         version: 4.17.21
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3)
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
 
   packages/rxbot:
     dependencies:
+      '@jest/globals':
+        specifier: ^29.7.0
+        version: 29.7.0
       '@rspack/cli':
         specifier: 1.1.0
         version: 1.1.0(@rspack/core@1.1.0)(@types/express@5.0.0)(webpack@5.96.1(@swc/core@1.7.14))
@@ -437,6 +440,9 @@ importers:
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
+      '@types/memory-fs':
+        specifier: ^0.3.7
+        version: 0.3.7
       '@types/yargs':
         specifier: ^17.0.33
         version: 17.0.33
@@ -449,6 +455,9 @@ importers:
       glob:
         specifier: ^11.0.0
         version: 11.0.0
+      memory-fs:
+        specifier: ^0.5.0
+        version: 0.5.0
       totalist:
         specifier: ^3.0.1
         version: 3.0.1
@@ -479,7 +488,7 @@ importers:
         version: 18.3.1
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)
@@ -525,7 +534,7 @@ importers:
         version: 29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3))
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3)
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -565,7 +574,7 @@ importers:
         version: 29.7.0
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3)
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -599,7 +608,7 @@ importers:
         version: 29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3))
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3)
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -626,7 +635,7 @@ importers:
         version: 29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3))
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3)
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -681,7 +690,7 @@ importers:
         version: link:../../packages/rxbot
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3)
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -2048,6 +2057,9 @@ packages:
 
   '@types/md5@2.3.5':
     resolution: {integrity: sha512-/i42wjYNgE6wf0j2bcTX6kuowmdL/6PE4IVitMpm2eYKBUuYCprdcWVK+xEF0gcV6ufMCRhtxmReGfc6hIK7Jw==}
+
+  '@types/memory-fs@0.3.7':
+    resolution: {integrity: sha512-wCRjyqBTpCsnPWDjYkG8x1Ym0ylHUXu2loom+CIXoP9syXvLAROnfghoNKAMSxvetmRXThMd1XSK2AffVT1WMQ==}
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
@@ -3512,6 +3524,10 @@ packages:
 
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
+
+  errno@0.1.8:
+    resolution: {integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==}
+    hasBin: true
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -5202,6 +5218,10 @@ packages:
     resolution: {integrity: sha512-JUeY0F/fQZgIod31Ja1eJgiSxLn7BfQlCnqhwXFBzFHEw63OdLK7VJUJ7bnzNsWgCyoUP5tEp1VRY8rDaYzqOA==}
     engines: {node: '>= 4.0.0'}
 
+  memory-fs@0.5.0:
+    resolution: {integrity: sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==}
+    engines: {node: '>=4.3.0 <5.0.0 || >=5.10'}
+
   meow@8.1.2:
     resolution: {integrity: sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==}
     engines: {node: '>=10'}
@@ -5979,6 +5999,9 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  prr@1.0.1:
+    resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
 
   psl@1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
@@ -8167,41 +8190,6 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.7.10)(@types/node@22.9.0)(typescript@5.6.3))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 22.9.0
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.10)(@types/node@22.9.0)(typescript@5.6.3))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.5
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3))':
     dependencies:
       '@jest/console': 29.7.0
@@ -8894,6 +8882,27 @@ snapshots:
       - webpack
       - webpack-cli
 
+  '@rspack/cli@1.1.0(@rspack/core@1.1.0)(webpack@5.96.1(@swc/core@1.7.14))':
+    dependencies:
+      '@discoveryjs/json-ext': 0.5.7
+      '@rspack/core': 1.1.0
+      '@rspack/dev-server': 1.0.9(@rspack/core@1.1.0)(webpack@5.96.1(@swc/core@1.7.14))
+      colorette: 2.0.19
+      exit-hook: 4.0.0
+      interpret: 3.1.1
+      rechoir: 0.8.0
+      semver: 7.6.3
+      webpack-bundle-analyzer: 4.6.1
+      yargs: 17.6.2
+    transitivePeerDependencies:
+      - '@types/express'
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+      - webpack
+      - webpack-cli
+
   '@rspack/core@1.1.0':
     dependencies:
       '@module-federation/runtime-tools': 0.5.1
@@ -8908,6 +8917,27 @@ snapshots:
       connect-history-api-fallback: 2.0.0
       express: 4.21.1
       http-proxy-middleware: 2.0.7(@types/express@5.0.0)
+      mime-types: 2.1.35
+      p-retry: 4.6.2
+      webpack-dev-middleware: 7.4.2(webpack@5.96.1(@swc/core@1.7.14))
+      webpack-dev-server: 5.0.4(webpack@5.96.1(@swc/core@1.7.14))
+      ws: 8.18.0
+    transitivePeerDependencies:
+      - '@types/express'
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+      - webpack
+      - webpack-cli
+
+  '@rspack/dev-server@1.0.9(@rspack/core@1.1.0)(webpack@5.96.1(@swc/core@1.7.14))':
+    dependencies:
+      '@rspack/core': 1.1.0
+      chokidar: 3.6.0
+      connect-history-api-fallback: 2.0.0
+      express: 4.21.1
+      http-proxy-middleware: 2.0.7(@types/express@4.17.21)
       mime-types: 2.1.35
       p-retry: 4.6.2
       webpack-dev-middleware: 7.4.2(webpack@5.96.1(@swc/core@1.7.14))
@@ -9242,6 +9272,10 @@ snapshots:
 
   '@types/md5@2.3.5': {}
 
+  '@types/memory-fs@0.3.7':
+    dependencies:
+      '@types/node': 22.9.0
+
   '@types/mime@1.3.5': {}
 
   '@types/minimatch@3.0.5': {}
@@ -9553,7 +9587,7 @@ snapshots:
 
   '@vercel/functions@1.4.1': {}
 
-  '@vercel/style-guide@5.2.0(eslint@8.57.0)(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)))(prettier@3.3.3)(typescript@5.6.3)':
+  '@vercel/style-guide@5.2.0(eslint@8.57.0)(jest@29.7.0(@types/node@22.9.0))(prettier@3.3.3)(typescript@5.6.3)':
     dependencies:
       '@babel/core': 7.23.3
       '@babel/eslint-parser': 7.23.3(@babel/core@7.23.3)(eslint@8.57.0)
@@ -9565,9 +9599,9 @@ snapshots:
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.17.0(eslint@8.57.0)(typescript@5.6.3))(eslint-plugin-import@2.29.0)(eslint@8.57.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
       eslint-plugin-import: 2.29.0(@typescript-eslint/parser@7.1.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)
-      eslint-plugin-jest: 27.6.0(@typescript-eslint/eslint-plugin@7.1.0(@typescript-eslint/parser@7.1.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3)
+      eslint-plugin-jest: 27.6.0(@typescript-eslint/eslint-plugin@7.1.0(@typescript-eslint/parser@7.1.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
-      eslint-plugin-playwright: 0.16.0(eslint-plugin-jest@27.6.0(@typescript-eslint/eslint-plugin@6.17.0(@typescript-eslint/parser@6.17.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3))(eslint@8.57.0)
+      eslint-plugin-playwright: 0.16.0(eslint-plugin-jest@27.6.0(@typescript-eslint/eslint-plugin@6.17.0(@typescript-eslint/parser@6.17.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3))(eslint@8.57.0)
       eslint-plugin-react: 7.33.2(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
       eslint-plugin-testing-library: 6.1.2(eslint@8.57.0)(typescript@5.6.3)
@@ -10550,21 +10584,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.6.3
 
-  create-jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.10)(@types/node@22.9.0)(typescript@5.6.3)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.10)(@types/node@22.9.0)(typescript@5.6.3))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   create-jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)):
     dependencies:
       '@jest/types': 29.6.3
@@ -10868,6 +10887,10 @@ snapshots:
 
   err-code@2.0.3: {}
 
+  errno@0.1.8:
+    dependencies:
+      prr: 1.0.1
+
   error-ex@1.3.2:
     dependencies:
       is-arrayish: 0.2.1
@@ -11128,7 +11151,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@27.6.0(@typescript-eslint/eslint-plugin@7.1.0(@typescript-eslint/parser@7.1.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3):
+  eslint-plugin-jest@27.6.0(@typescript-eslint/eslint-plugin@7.1.0(@typescript-eslint/parser@7.1.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.6.3)
       eslint: 8.57.0
@@ -11161,11 +11184,11 @@ snapshots:
 
   eslint-plugin-only-warn@1.1.0: {}
 
-  eslint-plugin-playwright@0.16.0(eslint-plugin-jest@27.6.0(@typescript-eslint/eslint-plugin@6.17.0(@typescript-eslint/parser@6.17.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3))(eslint@8.57.0):
+  eslint-plugin-playwright@0.16.0(eslint-plugin-jest@27.6.0(@typescript-eslint/eslint-plugin@6.17.0(@typescript-eslint/parser@6.17.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3))(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
     optionalDependencies:
-      eslint-plugin-jest: 27.6.0(@typescript-eslint/eslint-plugin@7.1.0(@typescript-eslint/parser@7.1.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3)
+      eslint-plugin-jest: 27.6.0(@typescript-eslint/eslint-plugin@7.1.0(@typescript-eslint/parser@7.1.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3)
 
   eslint-plugin-react-hooks@4.6.0(eslint@8.57.0):
     dependencies:
@@ -12472,25 +12495,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.10)(@types/node@22.9.0)(typescript@5.6.3)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.7.10)(@types/node@22.9.0)(typescript@5.6.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.10)(@types/node@22.9.0)(typescript@5.6.3))
-      exit: 0.1.2
-      import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.10)(@types/node@22.9.0)(typescript@5.6.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3))
@@ -12509,37 +12513,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
-
-  jest-config@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.10)(@types/node@22.9.0)(typescript@5.6.3)):
-    dependencies:
-      '@babel/core': 7.24.7
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.24.7)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.9.0
-      ts-node: 10.9.2(@swc/core@1.7.10)(@types/node@22.9.0)(typescript@5.6.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
 
   jest-config@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)):
     dependencies:
@@ -12807,18 +12780,6 @@ snapshots:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
-
-  jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.10)(@types/node@22.9.0)(typescript@5.6.3)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.7.10)(@types/node@22.9.0)(typescript@5.6.3))
-      '@jest/types': 29.6.3
-      import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.10)(@types/node@22.9.0)(typescript@5.6.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
 
   jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)):
     dependencies:
@@ -13238,6 +13199,11 @@ snapshots:
       '@jsonjoy.com/util': 1.5.0(tslib@2.6.2)
       tree-dump: 1.0.2(tslib@2.6.2)
       tslib: 2.6.2
+
+  memory-fs@0.5.0:
+    dependencies:
+      errno: 0.1.8
+      readable-stream: 2.3.8
 
   meow@8.1.2:
     dependencies:
@@ -14132,6 +14098,8 @@ snapshots:
       ipaddr.js: 1.9.1
 
   proxy-from-env@1.1.0: {}
+
+  prr@1.0.1: {}
 
   psl@1.9.0: {}
 
@@ -15141,26 +15109,7 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
-  ts-jest@29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.10)(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3):
-    dependencies:
-      bs-logger: 0.2.6
-      ejs: 3.1.10
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.10)(@types/node@22.9.0)(typescript@5.6.3))
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.6.3
-      typescript: 5.6.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.24.7
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.24.7)
-
-  ts-jest@29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0)(ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3)))(typescript@5.6.3):
+  ts-jest@29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
@@ -15178,27 +15127,6 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.24.7)
-
-  ts-node@10.9.2(@swc/core@1.7.10)(@types/node@22.9.0)(typescript@5.6.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 22.9.0
-      acorn: 8.14.0
-      acorn-walk: 8.3.2
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.6.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.7.10
-    optional: true
 
   ts-node@10.9.2(@swc/core@1.7.14)(@types/node@22.9.0)(typescript@5.6.3):
     dependencies:


### PR DESCRIPTION
This pull request includes significant updates to the `rxbot` package, focusing on improving the build process, enhancing testing capabilities, and refactoring the compiler to use an in-memory file system. The key changes include updating build scripts, adding new dependencies, and refactoring the compiler tests to use `memory-fs`.

### Build and Dependencies Updates:
* [`packages/rxbot/package.json`](diffhunk://#diff-107e6bcc8023cd708f83183cd1f2cfa489b9c35f79f1720a637fe4a94525e505L15-R15): Updated the build script to use `tsconfig.build.json` and added new dependencies `@jest/globals` and `@types/memory-fs`. [[1]](diffhunk://#diff-107e6bcc8023cd708f83183cd1f2cfa489b9c35f79f1720a637fe4a94525e505L15-R15) [[2]](diffhunk://#diff-107e6bcc8023cd708f83183cd1f2cfa489b9c35f79f1720a637fe4a94525e505R27) [[3]](diffhunk://#diff-107e6bcc8023cd708f83183cd1f2cfa489b9c35f79f1720a637fe4a94525e505R37-R42)
* [`packages/rxbot/tsconfig.build.json`](diffhunk://#diff-6e9dc2604dcdaf1004371f8dfc0844a6d01f0e4bfa4c74182319932c7f21452bR1-R7): Added a new TypeScript configuration file for the build process.
* [`packages/rxbot/tsconfig.json`](diffhunk://#diff-5e823137507495cace08519c817ce27cb6a9e5ecdf6a79df0a97fb79d1b8b9f5L7-R7): Enabled source maps for better debugging.

### Compiler Refactoring:
* [`packages/rxbot/src/compiler/compiler.ts`](diffhunk://#diff-0b540dd8051594471ed013dda5b4f92c71cfbb95e1e61f85450a68e848ad7d2aL31-R31): Refactored the compiler to use an in-memory file system (`memory-fs`) for testing purposes. Updated methods to use the in-memory file system instead of the native `fs` module. [[1]](diffhunk://#diff-0b540dd8051594471ed013dda5b4f92c71cfbb95e1e61f85450a68e848ad7d2aL31-R31) [[2]](diffhunk://#diff-0b540dd8051594471ed013dda5b4f92c71cfbb95e1e61f85450a68e848ad7d2aR42-R45) [[3]](diffhunk://#diff-0b540dd8051594471ed013dda5b4f92c71cfbb95e1e61f85450a68e848ad7d2aR116-R124) [[4]](diffhunk://#diff-0b540dd8051594471ed013dda5b4f92c71cfbb95e1e61f85450a68e848ad7d2aL211-R220) [[5]](diffhunk://#diff-0b540dd8051594471ed013dda5b4f92c71cfbb95e1e61f85450a68e848ad7d2aL233-R253) [[6]](diffhunk://#diff-0b540dd8051594471ed013dda5b4f92c71cfbb95e1e61f85450a68e848ad7d2aL255-R285) [[7]](diffhunk://#diff-0b540dd8051594471ed013dda5b4f92c71cfbb95e1e61f85450a68e848ad7d2aL352-R381) [[8]](diffhunk://#diff-0b540dd8051594471ed013dda5b4f92c71cfbb95e1e61f85450a68e848ad7d2aL382-R408) [[9]](diffhunk://#diff-0b540dd8051594471ed013dda5b4f92c71cfbb95e1e61f85450a68e848ad7d2aL517-R543)

### Testing Enhancements:
* [`packages/rxbot/src/compiler/compiler.spec.ts`](diffhunk://#diff-f57d4fbc7b889f89bfbb74bc9feec9031a0a768bcc5f7973fd006b1296a47037L1-L263): Updated compiler tests to use `memory-fs` for in-memory file operations and improved test coverage for route generation and error handling.

### Lockfile Updates:
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL185-R185): Updated lockfile to reflect changes in dependencies and their versions. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL185-R185) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL194-R194) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL221-R221) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL231-R231) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL271-R271) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL320-R320)